### PR TITLE
Get rid of separate signal parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,7 +905,6 @@ dependencies = [
  "glium",
  "image",
  "serde",
- "signal-hook",
  "takeable-option",
 ]
 
@@ -1455,25 +1454,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
 dependencies = [
  "lazy_static",
- "libc",
-]
-
-[[package]]
-name = "signal-hook"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
-dependencies = [
  "libc",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,6 +896,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "liver"
+version = "0.1.0"
+dependencies = [
+ "confy",
+ "cubism",
+ "expanduser",
+ "glium",
+ "image",
+ "serde",
+ "signal-hook",
+ "takeable-option",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,20 +1356,6 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
-
-[[package]]
-name = "rusty-ships"
-version = "0.1.0"
-dependencies = [
- "confy",
- "cubism",
- "expanduser",
- "glium",
- "image",
- "serde",
- "signal-hook",
- "takeable-option",
-]
 
 [[package]]
 name = "ryu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,4 @@ image = "0.24.7"
 serde = { version = "1.0.188", features = ["derive"]}
 confy = "0.5.1"
 takeable-option = "0.5.0"
-signal-hook = "0.3.17"
 expanduser = "1.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
-name = "rusty-ships"
+name = "liver"
 version = "0.1.0"
 authors = ["impossibleTea <impossibletea@icloud.com>"]
 edition = "2021"
 description = "Live2D model viewer with support for animation"
-repository = "https://github.com/impossibletea/rusty-ships"
+repository = "https://github.com/impossibletea/liver"
 license = "MIT"
-default-run = "rusty-ships"
+default-run = "liver"
 
 [[bin]]
-name = "rusty-ships"
+name = "liver"
 path = "src/main.rs"
 
 [[bin]]
-name = "rusty-ships-ctl"
+name = "bleed"
 path = "src/ctl.rs"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rusty Ships
+# Liver
 
 ## About
 
@@ -27,26 +27,26 @@ After that it is just as usual for rust projects:
 
 ```bash
 cargo install --path .
-rusty-ships
-ed ~/.config/rusty-ships/config.toml
-rusty-ships
+liver
+ed ~/.config/liver/config.toml
+liver
 # Window should appear
 ```
 
 ## Configuration
 
-Place your `config.toml` in `~/.config/rusty-ships/` (or wherever the config
-folder on your system is generated, refer to `confy` documentation[^confy]). 
+Place your `config.toml` in `~/.config/liver/` (or wherever the config folder
+on your system is generated, refer to `confy` documentation[^confy]). 
 
 Command-line arguments are supported. Short description is available via
-`rusty-ships -help`.
+`liver -help`.
 
 Config and its default parameters are as follows:
 
 ```toml
 [window]
 size = [800, 600]
-title = "Rusty Ships"
+title = "Liver"
 fit = "Cover"
 [window.bg]
 variant = "Color"
@@ -164,12 +164,10 @@ idle = ["Idle", "Idle"]
 
 ## Usage
 
-Launch the app with `rusty-ships`, optionally provide command line arguments.
-Window with your model should open, unless you forgot to set it in
-configuration.
+Launch the app with `liver`, optionally provide command line arguments. Window
+with your model should open, unless you forgot to set it in configuration.
 
-Playback can be controlled via `rusty-ships-ctl`. The following argumets are
-accepted:
+Playback can be controlled via `bleed`. The following argumets are accepted:
 
 * `set [class] <motion>`: Sets the motion from the class with that name, if
   available. Class can be omitted, in that case it will be treated as `""`
@@ -185,7 +183,7 @@ accepted:
 
 Xsecurelock[^xsl] is supported. Appropriate mode is launched based on a
 presence of `XSCREENSAVER_WINDOW` environment variable. Symlink app to the
-appropriate location with appropriate name (e.g. `saver_ships`), and it should
+appropriate location with appropriate name (e.g. `saver_liver`), and it should
 work automagically.
 
 [^live2d]: <https://www.live2d.com/en/>

--- a/README.md
+++ b/README.md
@@ -45,21 +45,29 @@ Config and its default parameters are as follows:
 
 ```toml
 [window]
-size = [800, 600]
-title = "Liver"
-fit = "Cover"
+size = [
+    800,
+    600,
+]
+title = 'Liver'
+fit = 'Cover'
+
 [window.bg]
-variant = "Color"
-color = [0.0, 0.0, 0.0, 0.0]
-image = ""
+variant = 'Color'
+color = [
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+]
+image = ''
 
 [model]
-name = ""
-path = "assets"
+path = 'assets'
+
 [model.motions]
 open = []
-idle = ""
-usr1 = ""
+idle = ''
 ```
 
 ### Window
@@ -119,9 +127,7 @@ Specifying `path` to model directory and a `name` of model config file
 #### Motions
 
 Configuration of motions that will be played at the program start (`open`, can
-be an array), a motion fallback (`idle`) when motion queue is empty, and a
-motion set when SIGUSR1 is received (`usr1`, Xsecurelock uses it when
-resetting saver).
+be an array), a motion fallback (`idle`) when motion queue is empty.
 
 Specified as a 2-size array, as Live2D motions have classes. So, for example,
 if your model has the following motion file references:

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,7 +103,6 @@ pub struct ModelConfig {
 pub struct MotionConfig {
     pub open: Vec<(String, String)>,
     pub idle: Option<(String, String)>,
-    pub usr1: Option<(String, String)>,
 }
 
 //   ____             __ _
@@ -142,7 +141,6 @@ impl Default for Config {
                 motions: MotionConfig {
                     open: Vec::new(),
                     idle: None,
-                    usr1: None,
                 },
             },
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use serde::{Serialize, Deserialize};
 
 pub mod constant {
-    pub const APP_NAME:   &'static str = "rusty-ships";
+    pub const APP_NAME:   &'static str = "liver";
     pub const CONFIG:     &'static str = "config";
 }
 use constant::*;
@@ -128,7 +128,7 @@ impl Default for Config {
         Self {
             window: WindowConfig {
                 size:  [800, 600],
-                title: "Rusty Ships".to_string(),
+                title: "Liver".to_string(),
                 fit:   FitConfig::Cover,
                 bg:    BgConfig {
                     variant: BgType::Color,

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -75,12 +75,6 @@ const CLI_ARGS: &[Cli] = &[
         act:   cli_motion_idle,
     },
     Cli {
-        name:  "-motion-usr1",
-        help:  "ID of model motion to play on receiving SIGUSR1",
-        usage: "<[class:]motion>",
-        act:   cli_motion_usr1,
-    },
-    Cli {
         name:  "-help",
         help:  "Show this help message and exit",
         usage: "",
@@ -399,34 +393,6 @@ fn cli_motion_idle(c: &mut Config,
     };
 
     c.model.motions.idle = Some((class, id));
-
-    Ok(())
-}
-
-//                        _   _                                  _
-//  _ _   _ __ ___   ___ | |_(_) ___  _ __  ___   _   _ ___ _ __/ |
-// (_|_) | '_ ` _ \ / _ \| __| |/ _ \| '_ \/ __| | | | / __| '__| |
-//  _ _  | | | | | | (_) | |_| | (_) | | | \__ \ | |_| \__ \ |  | |
-// (_|_) |_| |_| |_|\___/ \__|_|\___/|_| |_|___/  \__,_|___/_|  |_|
-
-fn cli_motion_usr1(c: &mut Config,
-                         a: &mut Args) -> Result<(), Box<dyn Error>>
-{
-    let motion =
-        a.next()
-        .ok_or("No model SIGUSR1 motion provided")?;
-
-    let mut split = motion.rsplit(':');
-    let id =
-        split.next()
-        .expect("motion")
-        .to_string();
-    let class = match split.next() {
-        Some(c) => c.to_string(),
-        None    => "".to_string()
-    };
-
-    c.model.motions.usr1 = Some((class, id));
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,10 +27,6 @@ use glium::{
         event_loop::EventLoopBuilder,
     },
 };
-use signal_hook::{
-    iterator::Signals,
-    consts::{SIGTERM, SIGUSR1},
-};
 
 mod config;
 use config::{Config, FitConfig, BgType};
@@ -102,25 +98,6 @@ fn main() -> Result<(), Box<dyn Error>>
             .and_then(|m| proxy.send_event(m)
                           .map_err(|e| format!("Failed to send message: {e}")))
             .unwrap_or_else(|e| eprintln!("{e}"))
-        });
-    });
-
-    let mut signals = Signals::new(&[SIGTERM, SIGUSR1])?;
-
-    let proxy = event_loop.create_proxy();
-    let usr1 = config.model.motions.usr1.clone();
-
-    thread::spawn(move || {
-        signals.forever()
-        .for_each(|signal| {
-            match signal {
-                SIGTERM => proxy.send_event(Message::Exit),
-                SIGUSR1 => match usr1.clone() {
-                    Some(t) => proxy.send_event(Message::SetMotion(t)),
-                    None    => Ok(())
-                }
-                _       => Ok(())
-            }.unwrap_or(());
         });
     });
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -5,7 +5,7 @@ use std::fmt::{
     Formatter,
 };
 
-pub const SOCKET_ADDR: &'static str = "/run/user/1000/rusty-ships.sock";
+pub const SOCKET_ADDR: &'static str = "/run/user/1000/liver.sock";
 pub const USAGE:       &'static str =
 "
 Usage:


### PR DESCRIPTION
Also rename:
```
rusty-ships     -> liver
rusty-ships-ctl -> bleed
```